### PR TITLE
Add conditional #[no_std] to crate root

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(non_camel_case_types, unstable_name_collisions)]
+#![cfg_attr(not(std), no_std)]
 
 //! Standback backports a number of methods, structs, and macros that have been
 //! stabilized in the Rust standard library since 1.31.0. This allows crate


### PR DESCRIPTION
I am pretty new to Rust and am using it for embedded. I was unable to compile this library for an embedded target even when supplying the `--no-default-features` build option as seen below:

(using rustc 1.44.0-nightly (94d346360 2020-04-09))
```
> cargo +nightly build --target thumbv7em-none-eabihf --no-default-features
   Compiling standback v0.2.2 (C:\Users\Peter\.cargo\registry\src\github.com1ecc6299db9ec823\standback-0.2.2)
error[E0463]: can't find crate for `std`
  |
  = note: the `thumbv7em-none-eabihf` target may not be installed
error: aborting due to previous error
For more information about this error, try `rustc --explain E0463`.
error: could not compile `standback`.
To learn more, run the command again with --verbose.
```

After making this change, the library compiled successfully.

I also noticed some unconditional std usage in 1_42.rs. I don't know if that file would also need to changed if using a pre-1.42 compiler. I imagine so.
