### PR TITLE
Add no_std support and CI check for embedded

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,6 +22,7 @@ jobs:
           - 1.41.0
           - 1.42.0
         os: [ubuntu-latest, windows-latest, macOS-latest]
+        target: [thumbv7em-none-eabihf]
 
     steps:
       - name: Checkout sources
@@ -32,13 +33,14 @@ jobs:
         with:
           profile: minimal
           toolchain: ${{ matrix.rust }}
+          target: ${{ matrix.target }}
           override: true
 
       - name: Run `cargo check --no-default-features`
         uses: actions-rs/cargo@v1
         with:
           command: check
-          args: --no-default-features
+          args: --no-default-features --target ${{ matrix.target }}
 
       - name: Run `cargo check`
         uses: actions-rs/cargo@v1

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,6 +22,48 @@ jobs:
           - 1.41.0
           - 1.42.0
         os: [ubuntu-latest, windows-latest, macOS-latest]
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          override: true
+
+      - name: Run `cargo check --no-default-features`
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --no-default-features
+
+      - name: Run `cargo check`
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+
+  check-embedded:
+    name: Type checking on embedded
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        rust:
+          - 1.31.0
+          - 1.32.0
+          - 1.33.0
+          - 1.34.0
+          - 1.35.0
+          - 1.36.0
+          - 1.37.0
+          - 1.38.0
+          - 1.39.0
+          - 1.40.0
+          - 1.41.0
+          - 1.42.0
+        os: [ubuntu-latest]
         target: [thumbv7em-none-eabihf]
 
     steps:
@@ -36,22 +78,11 @@ jobs:
           target: ${{ matrix.target }}
           override: true
 
-      - name: Run `cargo check --no-default-features` with embedded target
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --no-default-features --target ${{ matrix.target }}
-
       - name: Run `cargo check --no-default-features`
         uses: actions-rs/cargo@v1
         with:
           command: check
-          args: --no-default-features
-
-      - name: Run `cargo check`
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
+          args: --no-default-features --target ${{ matrix.target }}
 
   fmt:
     name: Formatting

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -36,11 +36,17 @@ jobs:
           target: ${{ matrix.target }}
           override: true
 
-      - name: Run `cargo check --no-default-features`
+      - name: Run `cargo check --no-default-features` with embedded target
         uses: actions-rs/cargo@v1
         with:
           command: check
           args: --no-default-features --target ${{ matrix.target }}
+
+      - name: Run `cargo check --no-default-features`
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --no-default-features
 
       - name: Run `cargo check`
         uses: actions-rs/cargo@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "standback"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["Jacob Pratt <the.z.cuber@gmail.com>", "The Rust Project Developers"]
 edition = "2018"
 repository = "https://github.com/jhpratt/standback"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -424,8 +424,10 @@ pub mod prelude {
     pub use crate::v1_38::{
         ConstPtr_v1_38, Duration_v1_38, EuclidFloat_v1_38, Euclid_v1_38, MutPtr_v1_38,
     };
+    #[cfg(all(std, before_1_40))]
+    pub use crate::v1_40::slice_v1_40;
     #[cfg(before_1_40)]
-    pub use crate::v1_40::{f32_v1_40, f64_v1_40, slice_v1_40, Option_v1_40, Option_v1_40_};
+    pub use crate::v1_40::{f32_v1_40, f64_v1_40, Option_v1_40, Option_v1_40_};
     #[cfg(before_1_41)]
     pub use crate::v1_41::Result_v1_41;
     #[cfg(all(before_1_42, std))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(non_camel_case_types, unstable_name_collisions)]
+#![cfg_attr(not(std), no_std)]
 
 //! Standback backports a number of methods, structs, and macros that have been
 //! stabilized in the Rust standard library since 1.31.0. This allows crate

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -428,8 +428,10 @@ pub mod prelude {
     pub use crate::v1_40::{f32_v1_40, f64_v1_40, slice_v1_40, Option_v1_40, Option_v1_40_};
     #[cfg(before_1_41)]
     pub use crate::v1_41::Result_v1_41;
+    #[cfg(all(before_1_42, std))]
+    pub use crate::v1_42::Condvar_v1_42;
     #[cfg(before_1_42)]
-    pub use crate::v1_42::{Condvar_v1_42, ManuallyDrop_v1_42};
+    pub use crate::v1_42::ManuallyDrop_v1_42;
     #[cfg(before_1_39)]
     pub use core::unimplemented as todo;
 }

--- a/src/v1_34.rs
+++ b/src/v1_34.rs
@@ -2,7 +2,10 @@ mod try_from;
 
 pub use self::try_from::{TryFrom, TryFromIntError, TryInto};
 pub use crate::array::TryFromSliceError;
-use core::{fmt, iter::FusedIterator, mem};
+use core::{fmt, iter::FusedIterator};
+
+#[cfg(std)]
+use core::mem;
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Infallible {}
@@ -106,6 +109,7 @@ pub trait Slice_v1_34<T>: private_slice::Sealed {
         K: Ord;
 }
 
+#[cfg(std)]
 impl<T> Slice_v1_34<T> for [T] {
     #[inline]
     fn sort_by_cached_key<K, F>(&mut self, f: F)

--- a/src/v1_38.rs
+++ b/src/v1_38.rs
@@ -306,6 +306,7 @@ pub trait EuclidFloat_v1_38: private_euclid_float::Sealed {
     fn div_euclid(self, rhs: Self) -> Self;
 }
 
+#[cfg(std)]
 impl EuclidFloat_v1_38 for f32 {
     #[must_use = "method returns a new number and does not mutate the original value"]
     #[inline]
@@ -329,6 +330,7 @@ impl EuclidFloat_v1_38 for f32 {
     }
 }
 
+#[cfg(std)]
 impl EuclidFloat_v1_38 for f64 {
     #[must_use = "method returns a new number and does not mutate the original value"]
     #[inline]

--- a/src/v1_40.rs
+++ b/src/v1_40.rs
@@ -1,6 +1,6 @@
 #[cfg(before_1_32)]
 use crate::v1_32::{u32_v1_32, u64_v1_32};
-use core::{ops::DerefMut};
+use core::ops::DerefMut;
 
 #[cfg(std)]
 use core::ptr;

--- a/src/v1_40.rs
+++ b/src/v1_40.rs
@@ -1,6 +1,9 @@
 #[cfg(before_1_32)]
 use crate::v1_32::{u32_v1_32, u64_v1_32};
-use core::{ops::DerefMut, ptr};
+use core::{ops::DerefMut};
+
+#[cfg(std)]
+use core::ptr;
 
 mod private_option {
     pub trait Sealed {}
@@ -138,12 +141,14 @@ mod private_slice {
     impl<T> Sealed for [T] {}
 }
 
+#[cfg(std)]
 pub trait slice_v1_40<T>: private_slice::Sealed {
     fn repeat(&self, n: usize) -> Vec<T>
     where
         T: Copy;
 }
 
+#[cfg(std)]
 impl<T: Copy> slice_v1_40<T> for [T] {
     fn repeat(&self, n: usize) -> Vec<T> {
         if n == 0 {

--- a/src/v1_42.rs
+++ b/src/v1_42.rs
@@ -1,9 +1,12 @@
 use core::{mem::ManuallyDrop, ptr, time::Duration};
+
+#[cfg_attr(not(std), no_std)]
 use std::{
     sync::{Condvar, LockResult, MutexGuard, WaitTimeoutResult},
     time::Instant,
 };
 
+#[cfg_attr(not(std), no_std)]
 #[inline(always)]
 fn new_wait_timeout_result(value: bool) -> WaitTimeoutResult {
     // Safety: WaitTimeoutResult is a thin wrapper around a boolean. As the
@@ -13,11 +16,13 @@ fn new_wait_timeout_result(value: bool) -> WaitTimeoutResult {
     unsafe { core::mem::transmute(value) }
 }
 
+#[cfg_attr(not(std), no_std)]
 mod private_condvar {
     pub trait Sealed {}
     impl Sealed for super::Condvar {}
 }
 
+#[cfg_attr(not(std), no_std)]
 pub trait Condvar_v1_42: private_condvar::Sealed {
     fn wait_while<'a, T, F>(
         &self,
@@ -36,6 +41,7 @@ pub trait Condvar_v1_42: private_condvar::Sealed {
         F: FnMut(&mut T) -> bool;
 }
 
+#[cfg_attr(not(std), no_std)]
 impl Condvar_v1_42 for Condvar {
     fn wait_while<'a, T, F>(
         &self,

--- a/src/v1_42.rs
+++ b/src/v1_42.rs
@@ -1,12 +1,8 @@
 use core::{mem::ManuallyDrop, ptr};
-
-#[cfg(std)]
-use core::time::Duration;
-
 #[cfg(std)]
 use std::{
     sync::{Condvar, LockResult, MutexGuard, WaitTimeoutResult},
-    time::Instant,
+    time::{Duration, Instant},
 };
 
 #[cfg(std)]

--- a/src/v1_42.rs
+++ b/src/v1_42.rs
@@ -1,4 +1,7 @@
-use core::{mem::ManuallyDrop, ptr, time::Duration};
+use core::{mem::ManuallyDrop, ptr};
+
+#[cfg(std)]
+use core::time::Duration;
 
 #[cfg(std)]
 use std::{

--- a/src/v1_42.rs
+++ b/src/v1_42.rs
@@ -1,12 +1,12 @@
 use core::{mem::ManuallyDrop, ptr, time::Duration};
 
-#[cfg_attr(not(std), no_std)]
+#[cfg(std)]
 use std::{
     sync::{Condvar, LockResult, MutexGuard, WaitTimeoutResult},
     time::Instant,
 };
 
-#[cfg_attr(not(std), no_std)]
+#[cfg(std)]
 #[inline(always)]
 fn new_wait_timeout_result(value: bool) -> WaitTimeoutResult {
     // Safety: WaitTimeoutResult is a thin wrapper around a boolean. As the
@@ -16,13 +16,13 @@ fn new_wait_timeout_result(value: bool) -> WaitTimeoutResult {
     unsafe { core::mem::transmute(value) }
 }
 
-#[cfg_attr(not(std), no_std)]
+#[cfg(std)]
 mod private_condvar {
     pub trait Sealed {}
     impl Sealed for super::Condvar {}
 }
 
-#[cfg_attr(not(std), no_std)]
+#[cfg(std)]
 pub trait Condvar_v1_42: private_condvar::Sealed {
     fn wait_while<'a, T, F>(
         &self,
@@ -41,7 +41,7 @@ pub trait Condvar_v1_42: private_condvar::Sealed {
         F: FnMut(&mut T) -> bool;
 }
 
-#[cfg_attr(not(std), no_std)]
+#[cfg(std)]
 impl Condvar_v1_42 for Condvar {
     fn wait_while<'a, T, F>(
         &self,


### PR DESCRIPTION
I am pretty new to Rust and am using it for embedded. I was unable to compile this library for an embedded target even when supplying the `--no-default-features` build option as seen below:

(using rustc 1.44.0-nightly (94d346360 2020-04-09))
```
> cargo +nightly build --target thumbv7em-none-eabihf --no-default-features
   Compiling standback v0.2.2 (C:\Users\Peter\.cargo\registry\src\github.com1ecc6299db9ec823\standback-0.2.2)
error[E0463]: can't find crate for `std`
  |
  = note: the `thumbv7em-none-eabihf` target may not be installed
error: aborting due to previous error
For more information about this error, try `rustc --explain E0463`.
error: could not compile `standback`.
To learn more, run the command again with --verbose.
```

I added a conditional `#![no_std]` in the crate root (not(std)) and also as well as in `1_42.rs` where needed. In addition, I added an embedded target for the check performed with the `--no-default-features` flag. It is my understanding that this is one option to ensure that the check actually fails if not `no_std`. It does appear that rustc versions before 1.42 will still fail. I'm not sure what would be required to get those working. 

